### PR TITLE
feat: restore missing nodoInviaCarrelloRPT scenarios

### DIFF
--- a/.github/instructions/git-pr.instructions.md
+++ b/.github/instructions/git-pr.instructions.md
@@ -17,6 +17,7 @@
 - Run `git diff main...HEAD --name-only` to list changed files.
 - Run `git diff main...HEAD --shortstat` for compact change size.
 - Compose PR body inline using [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md) sections (do not pass template file directly).
+- Infer title: <branch codename> - <short semantic changes analysis>.
 
 ### Fallback for ambiguous scope
 

--- a/src/integration/utility/wisp/utils.py
+++ b/src/integration/utility/wisp/utils.py
@@ -105,15 +105,15 @@ def get_current_date():
 def get_index_from_cardinal(cardinal):
     index = -1
     match cardinal:
-        case 'first':
+        case 'prima':
             index = 0
-        case 'second':
+        case 'seconda':
             index = 1
-        case 'third':
+        case 'terza':
             index = 2
-        case 'fourth':
+        case 'quarta':
             index = 3
-        case 'fifth':
+        case 'quinta':
             index = 4
     return index
 

--- a/src/integration/wisp/features/nodoInviaCarrelloRPT/nodoInviaCarrelloRPT_existingPaymentPosition.feature
+++ b/src/integration/wisp/features/nodoInviaCarrelloRPT/nodoInviaCarrelloRPT_existingPaymentPosition.feature
@@ -13,7 +13,7 @@ Funzionalità: L'utente paga carrelli di pagamento da posizione debitoria esiste
   Scenario: L'utente paga un carrello con singola RPT senza marca da bollo gia esistente in GPD
     Dato un carrello di RPT non multi-beneficiario
     E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
-    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 48 e stato uguale a VALID
+    E una posizione debitoria esistente relativa alla prima RPT con segregation code uguale a 48 e stato uguale a VALID
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
     Allora l'utente viene reindirizzato su Checkout completando il pagamento
     E la posizione debitoria è chiusa
@@ -26,7 +26,7 @@ Funzionalità: L'utente paga carrelli di pagamento da posizione debitoria esiste
   Scenario: L'utente paga un carrello con singola RPT con versamenti multipli gia esistente in GPD
     Dato un carrello di RPT non multi-beneficiario
     E una singola RPT di tipo BBT con 3 versamenti di cui none sono marche da bollo
-    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 48 e stato uguale a VALID
+    E una posizione debitoria esistente relativa alla prima RPT con segregation code uguale a 48 e stato uguale a VALID
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
     Allora l'utente viene reindirizzato su Checkout completando il pagamento
     E la posizione debitoria è chiusa
@@ -39,7 +39,7 @@ Funzionalità: L'utente paga carrelli di pagamento da posizione debitoria esiste
   Scenario: L'utente paga un carrello con singola RPT con una marca da bollo gia esistente in GPD
     Dato un carrello di RPT non multi-beneficiario
     E una singola RPT di tipo BBT con 2 versamenti di cui 1 sono marche da bollo
-    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 48 e stato uguale a VALID
+    E una posizione debitoria esistente relativa alla prima RPT con segregation code uguale a 48 e stato uguale a VALID
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
     Allora l'utente viene reindirizzato su Checkout completando il pagamento
     E la posizione debitoria è chiusa
@@ -53,7 +53,7 @@ Funzionalità: L'utente paga carrelli di pagamento da posizione debitoria esiste
     Dato un carrello di RPT non multi-beneficiario
     E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
     E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
-    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 48 e stato uguale a VALID
+    E una posizione debitoria esistente relativa alla prima RPT con segregation code uguale a 48 e stato uguale a VALID
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
     Allora l'utente viene reindirizzato su Checkout completando il pagamento
     E la posizione debitoria è chiusa
@@ -67,7 +67,7 @@ Funzionalità: L'utente paga carrelli di pagamento da posizione debitoria esiste
     Dato un carrello di RPT non multi-beneficiario
     E una singola RPT di tipo BBT con 3 versamenti di cui none sono marche da bollo
     E una singola RPT di tipo BBT con 3 versamenti di cui none sono marche da bollo
-    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 48 e stato uguale a VALID
+    E una posizione debitoria esistente relativa alla prima RPT con segregation code uguale a 48 e stato uguale a VALID
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
     Allora l'utente viene reindirizzato su Checkout completando il pagamento
     E la posizione debitoria è chiusa
@@ -81,7 +81,7 @@ Funzionalità: L'utente paga carrelli di pagamento da posizione debitoria esiste
     Dato un carrello di RPT non multi-beneficiario
     E una singola RPT di tipo BBT con 2 versamenti di cui 1 sono marche da bollo
     E una singola RPT di tipo BBT con 3 versamenti di cui 1 sono marche da bollo
-    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 48 e stato uguale a VALID
+    E una posizione debitoria esistente relativa alla prima RPT con segregation code uguale a 48 e stato uguale a VALID
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
     Allora l'utente viene reindirizzato su Checkout completando il pagamento
     E la posizione debitoria è chiusa
@@ -94,7 +94,7 @@ Funzionalità: L'utente paga carrelli di pagamento da posizione debitoria esiste
   Scenario: L'utente tenta di pagare un carrello con singola RPT gia esistente in GPD in stato non valido
     Dato un carrello di RPT non multi-beneficiario
     E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
-    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 48 e stato uguale a DRAFT
+    E una posizione debitoria esistente relativa alla prima RPT con segregation code uguale a 48 e stato uguale a DRAFT
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
     Allora la conversione al nuovo modello fallisce nel wisp-converter
     E la ricevuta KO è inviata
@@ -107,7 +107,7 @@ Funzionalità: L'utente paga carrelli di pagamento da posizione debitoria esiste
   Scenario: L'utente tenta di pagare un carrello con singola RPT inserita da ACA e in stato valido
     Dato un carrello di RPT non multi-beneficiario
     E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
-    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 01 e stato uguale a VALID
+    E una posizione debitoria esistente relativa alla prima RPT con segregation code uguale a 01 e stato uguale a VALID
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
     Allora la conversione al nuovo modello fallisce nel wisp-converter
     E la ricevuta KO è inviata
@@ -120,7 +120,7 @@ Funzionalità: L'utente paga carrelli di pagamento da posizione debitoria esiste
   Scenario: L'utente tenta di pagare un carrello con singola RPT inserita da ACA e in stato non valido
     Dato un carrello di RPT non multi-beneficiario
     E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
-    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 01 e stato uguale a DRAFT
+    E una posizione debitoria esistente relativa alla prima RPT con segregation code uguale a 01 e stato uguale a DRAFT
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
     Allora la conversione al nuovo modello fallisce nel wisp-converter
     E la ricevuta KO è inviata
@@ -134,7 +134,7 @@ Funzionalità: L'utente paga carrelli di pagamento da posizione debitoria esiste
     Dato un carrello di RPT non multi-beneficiario
     E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
     E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
-    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 48 e stato uguale a DRAFT
+    E una posizione debitoria esistente relativa alla prima RPT con segregation code uguale a 48 e stato uguale a DRAFT
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
     Allora la conversione al nuovo modello fallisce nel wisp-converter
     E la ricevuta KO è inviata
@@ -148,7 +148,7 @@ Funzionalità: L'utente paga carrelli di pagamento da posizione debitoria esiste
     Dato un carrello di RPT non multi-beneficiario
     E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
     E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
-    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 01 e stato uguale a VALID
+    E una posizione debitoria esistente relativa alla prima RPT con segregation code uguale a 01 e stato uguale a VALID
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
     Allora la conversione al nuovo modello fallisce nel wisp-converter
     E la ricevuta KO è inviata
@@ -162,7 +162,7 @@ Funzionalità: L'utente paga carrelli di pagamento da posizione debitoria esiste
     Dato un carrello di RPT non multi-beneficiario
     E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
     E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
-    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 01 e stato uguale a DRAFT
+    E una posizione debitoria esistente relativa alla prima RPT con segregation code uguale a 01 e stato uguale a DRAFT
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
     Allora la conversione al nuovo modello fallisce nel wisp-converter
     E la ricevuta KO è inviata
@@ -176,7 +176,7 @@ Funzionalità: L'utente paga carrelli di pagamento da posizione debitoria esiste
     Dato un carrello di RPT multi-beneficiario
     E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
     E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
-    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 48 e stato uguale a DRAFT
+    E una posizione debitoria esistente relativa alla prima RPT con segregation code uguale a 48 e stato uguale a DRAFT
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
     Allora la conversione al nuovo modello fallisce nel wisp-converter
     E la ricevuta KO è inviata
@@ -190,7 +190,7 @@ Funzionalità: L'utente paga carrelli di pagamento da posizione debitoria esiste
     Dato un carrello di RPT multi-beneficiario
     E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
     E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
-    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 01 e stato uguale a VALID
+    E una posizione debitoria esistente relativa alla prima RPT con segregation code uguale a 01 e stato uguale a VALID
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
     Allora la conversione al nuovo modello fallisce nel wisp-converter
     E la ricevuta KO è inviata
@@ -204,7 +204,7 @@ Funzionalità: L'utente paga carrelli di pagamento da posizione debitoria esiste
     Dato un carrello di RPT multi-beneficiario
     E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
     E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
-    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 01 e stato uguale a DRAFT
+    E una posizione debitoria esistente relativa alla prima RPT con segregation code uguale a 01 e stato uguale a DRAFT
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
     Allora la conversione al nuovo modello fallisce nel wisp-converter
     E la ricevuta KO è inviata
@@ -218,7 +218,7 @@ Funzionalità: L'utente paga carrelli di pagamento da posizione debitoria esiste
     Dato un carrello di RPT multi-beneficiario
     E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
     E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
-    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 48 e stato uguale a VALID
+    E una posizione debitoria esistente relativa alla prima RPT con segregation code uguale a 48 e stato uguale a VALID
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
     Allora la conversione al nuovo modello fallisce nel wisp-converter
     E la ricevuta KO è inviata

--- a/src/integration/wisp/features/nodoInviaCarrelloRPT/nodoInviaCarrelloRPT_existingPaymentPosition.feature
+++ b/src/integration/wisp/features/nodoInviaCarrelloRPT/nodoInviaCarrelloRPT_existingPaymentPosition.feature
@@ -138,3 +138,87 @@ Funzionalità: L'utente paga carrelli di pagamento da posizione debitoria esiste
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
     Allora la conversione al nuovo modello fallisce nel wisp-converter
     E la ricevuta KO è inviata
+
+  # ===============================================================================================
+  # ===============================================================================================
+
+  @runnable @nodo_invia_carrello_rpt @unhappy_path
+  @FEAT_006_NodoInviaCarrelloRPT_ExistingPaymentPosition_SCENARIO_11
+  Scenario: L'utente tenta di pagare un carrello con due RPT inserite da ACA e in stato valido
+    Dato un carrello di RPT non multi-beneficiario
+    E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
+    E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
+    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 01 e stato uguale a VALID
+    Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
+    Allora la conversione al nuovo modello fallisce nel wisp-converter
+    E la ricevuta KO è inviata
+
+  # ===============================================================================================
+  # ===============================================================================================
+
+  @runnable @nodo_invia_carrello_rpt @unhappy_path
+  @FEAT_006_NodoInviaCarrelloRPT_ExistingPaymentPosition_SCENARIO_12
+  Scenario: L'utente tenta di pagare un carrello con due RPT inserite da ACA e in stato non valido
+    Dato un carrello di RPT non multi-beneficiario
+    E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
+    E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
+    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 01 e stato uguale a DRAFT
+    Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
+    Allora la conversione al nuovo modello fallisce nel wisp-converter
+    E la ricevuta KO è inviata
+
+  # ===============================================================================================
+  # ===============================================================================================
+
+  @runnable @nodo_invia_carrello_rpt @unhappy_path
+  @FEAT_006_NodoInviaCarrelloRPT_ExistingPaymentPosition_SCENARIO_13
+  Scenario: L'utente tenta di pagare un carrello multibeneficiario gia esistente in GPD in stato non valido
+    Dato un carrello di RPT multi-beneficiario
+    E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
+    E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
+    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 48 e stato uguale a DRAFT
+    Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
+    Allora la conversione al nuovo modello fallisce nel wisp-converter
+    E la ricevuta KO è inviata
+
+  # ===============================================================================================
+  # ===============================================================================================
+
+  @runnable @nodo_invia_carrello_rpt @unhappy_path
+  @FEAT_006_NodoInviaCarrelloRPT_ExistingPaymentPosition_SCENARIO_14
+  Scenario: L'utente tenta di pagare un carrello multibeneficiario inserito da ACA e in stato valido
+    Dato un carrello di RPT multi-beneficiario
+    E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
+    E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
+    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 01 e stato uguale a VALID
+    Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
+    Allora la conversione al nuovo modello fallisce nel wisp-converter
+    E la ricevuta KO è inviata
+
+  # ===============================================================================================
+  # ===============================================================================================
+
+  @runnable @nodo_invia_carrello_rpt @unhappy_path
+  @FEAT_006_NodoInviaCarrelloRPT_ExistingPaymentPosition_SCENARIO_15
+  Scenario: L'utente tenta di pagare un carrello multibeneficiario inserito da ACA e in stato non valido
+    Dato un carrello di RPT multi-beneficiario
+    E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
+    E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
+    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 01 e stato uguale a DRAFT
+    Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
+    Allora la conversione al nuovo modello fallisce nel wisp-converter
+    E la ricevuta KO è inviata
+
+  # ===============================================================================================
+  # ===============================================================================================
+
+  @runnable @nodo_invia_carrello_rpt @unhappy_path
+  @FEAT_006_NodoInviaCarrelloRPT_ExistingPaymentPosition_SCENARIO_16
+  Scenario: L'utente paga un carrello multibeneficiario gia esistente in GPD
+    Dato un carrello di RPT multi-beneficiario
+    E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
+    E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
+    E una posizione debitoria esistente relativa alla first RPT con segregation code uguale a 48 e stato uguale a VALID
+    Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
+    Allora la conversione al nuovo modello fallisce nel wisp-converter
+    E la ricevuta KO è inviata

--- a/src/integration/wisp/features/nodoInviaCarrelloRPT/nodoInviaCarrelloRPT_noStamp.feature
+++ b/src/integration/wisp/features/nodoInviaCarrelloRPT/nodoInviaCarrelloRPT_noStamp.feature
@@ -163,7 +163,7 @@ Funzionalità: L'utente paga carrelli di pagamento senza marche da bollo su nodo
     Dato un carrello di RPT non-multi-beneficiario
     E una singola RPT di tipo BBT con 6 versamenti di cui none sono marche da bollo
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC senza verifica dell'URL di redirect
-    Allora il pagamento fallisce having a quantity of transfers above the limit e viene restituito l'errore PPT_SINTASSI_XSD
+    Allora il pagamento fallisce essendo il numero di versamenti oltre il limite e viene restituito l'errore PPT_SINTASSI_XSD
 
   # ===============================================================================================
   # ===============================================================================================
@@ -176,7 +176,7 @@ Funzionalità: L'utente paga carrelli di pagamento senza marche da bollo su nodo
     E una singola RPT di tipo BBT con 6 versamenti di cui none sono marche da bollo
     E una singola RPT di tipo BBT con 6 versamenti di cui none sono marche da bollo
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC senza verifica dell'URL di redirect
-    Allora il pagamento fallisce having a quantity of transfers above the limit e viene restituito l'errore PPT_SINTASSI_XSD
+    Allora il pagamento fallisce essendo il numero di versamenti oltre il limite e viene restituito l'errore PPT_SINTASSI_XSD
 
   # ===============================================================================================
   # ===============================================================================================

--- a/src/integration/wisp/features/nodoInviaCarrelloRPT/nodoInviaCarrelloRPT_noStamp.feature
+++ b/src/integration/wisp/features/nodoInviaCarrelloRPT/nodoInviaCarrelloRPT_noStamp.feature
@@ -101,3 +101,91 @@ Funzionalità: L'utente paga carrelli di pagamento senza marche da bollo su nodo
     E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
     Allora l'utente viene reindirizzato su Checkout completando il pagamento
+
+  # ===============================================================================================
+  # ===============================================================================================
+
+  @runnable @nodo_invia_carrello_rpt @happy_path
+  @FEAT_004_NodoInviaCarrelloRPT_NoStamp_SCENARIO_09
+  Scenario: L'utente paga un carrello con due RPT per un totale di cinque versamenti
+    Dato un carrello di RPT non-multi-beneficiario
+    E una singola RPT di tipo BBT con 2 versamenti di cui none sono marche da bollo
+    E una singola RPT di tipo BBT con 3 versamenti di cui none sono marche da bollo
+    Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
+    Allora l'utente viene reindirizzato su Checkout completando il pagamento
+
+  # ===============================================================================================
+  # ===============================================================================================
+
+  @runnable @nodo_invia_carrello_rpt @happy_path
+  @FEAT_004_NodoInviaCarrelloRPT_NoStamp_SCENARIO_10
+  Scenario: L'utente paga un carrello con tre RPT per un totale di cinque versamenti
+    Dato un carrello di RPT non-multi-beneficiario
+    E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
+    E una singola RPT di tipo BBT con 2 versamenti di cui none sono marche da bollo
+    E una singola RPT di tipo BBT con 2 versamenti di cui none sono marche da bollo
+    Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
+    Allora l'utente viene reindirizzato su Checkout completando il pagamento
+
+  # ===============================================================================================
+  # ===============================================================================================
+
+  @runnable @nodo_invia_carrello_rpt @happy_path
+  @FEAT_004_NodoInviaCarrelloRPT_NoStamp_SCENARIO_11
+  Scenario: L'utente paga un carrello con tre RPT per un totale di dieci versamenti
+    Dato un carrello di RPT non-multi-beneficiario
+    E una singola RPT di tipo BBT con 3 versamenti di cui none sono marche da bollo
+    E una singola RPT di tipo BBT con 3 versamenti di cui none sono marche da bollo
+    E una singola RPT di tipo BBT con 4 versamenti di cui none sono marche da bollo
+    Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
+    Allora l'utente viene reindirizzato su Checkout completando il pagamento
+
+  # ===============================================================================================
+  # ===============================================================================================
+
+  @runnable @nodo_invia_carrello_rpt @happy_path
+  @FEAT_004_NodoInviaCarrelloRPT_NoStamp_SCENARIO_12
+  Scenario: L'utente tenta di pagare un carrello con due RPT ma la chiusura del pagamento fallisce, poi ritenta con successo
+    Dato un carrello di RPT non-multi-beneficiario
+    E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
+    E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
+    E l'utente tenta di pagare il carrello di RPT sul sito dell'EC
+    E l'utente viene reindirizzato su Checkout senza completare il pagamento multibeneficiario
+    Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
+    Allora l'utente viene reindirizzato su Checkout completando il pagamento multibeneficiario
+
+  # ===============================================================================================
+  # ===============================================================================================
+
+  @runnable @nodo_invia_carrello_rpt @unhappy_path
+  @FEAT_004_NodoInviaCarrelloRPT_NoStamp_SCENARIO_13
+  Scenario: L'utente tenta di pagare un carrello con una RPT che ha una quantita di versamenti oltre il limite
+    Dato un carrello di RPT non-multi-beneficiario
+    E una singola RPT di tipo BBT con 6 versamenti di cui none sono marche da bollo
+    Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC senza verifica dell'URL di redirect
+    Allora il pagamento fallisce having a quantity of transfers above the limit e viene restituito l'errore PPT_SINTASSI_XSD
+
+  # ===============================================================================================
+  # ===============================================================================================
+
+  @runnable @nodo_invia_carrello_rpt @unhappy_path
+  @FEAT_004_NodoInviaCarrelloRPT_NoStamp_SCENARIO_14
+  Scenario: L'utente tenta di pagare un carrello con due RPT che hanno una quantita di versamenti oltre il limite
+    Dato un carrello di RPT non-multi-beneficiario
+    E una singola RPT di tipo BBT con 2 versamenti di cui none sono marche da bollo
+    E una singola RPT di tipo BBT con 6 versamenti di cui none sono marche da bollo
+    E una singola RPT di tipo BBT con 6 versamenti di cui none sono marche da bollo
+    Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC senza verifica dell'URL di redirect
+    Allora il pagamento fallisce having a quantity of transfers above the limit e viene restituito l'errore PPT_SINTASSI_XSD
+
+  # ===============================================================================================
+  # ===============================================================================================
+
+  @runnable @nodo_invia_carrello_rpt @unhappy_path
+  @FEAT_004_NodoInviaCarrelloRPT_NoStamp_SCENARIO_15
+  Scenario: L'utente tenta di pagare un carrello con due RPT ma la chiusura del pagamento fallisce
+    Dato un carrello di RPT non-multi-beneficiario
+    E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
+    E una singola RPT di tipo BBT con 1 versamenti di cui none sono marche da bollo
+    Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC
+    Allora l'utente viene reindirizzato su Checkout senza completare il pagamento multibeneficiario

--- a/src/integration/wisp/features/nodoInviaCarrelloRPT/nodoInviaCarrelloRPT_withStamp.feature
+++ b/src/integration/wisp/features/nodoInviaCarrelloRPT/nodoInviaCarrelloRPT_withStamp.feature
@@ -96,7 +96,7 @@ Funzionalità: L'utente paga carrelli di pagamento con marche da bollo su nodoIn
     Dato un carrello di RPT non-multi-beneficiario
     E una singola RPT di tipo BBT con 6 versamenti di cui 3 sono marche da bollo
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC senza verifica dell'URL di redirect
-    Allora il pagamento fallisce having a quantity of transfers above the limit e viene restituito l'errore PPT_SINTASSI_XSD
+    Allora il pagamento fallisce essendo il numero di versamenti oltre il limite e viene restituito l'errore PPT_SINTASSI_XSD
 
   # ===============================================================================================
   # ===============================================================================================
@@ -108,4 +108,4 @@ Funzionalità: L'utente paga carrelli di pagamento con marche da bollo su nodoIn
     E una singola RPT di tipo BBT con 2 versamenti di cui 1 sono marche da bollo
     E una singola RPT di tipo BBT con 6 versamenti di cui 2 sono marche da bollo
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC senza verifica dell'URL di redirect
-    Allora il pagamento fallisce having a quantity of transfers above the limit e viene restituito l'errore PPT_SINTASSI_XSD
+    Allora il pagamento fallisce essendo il numero di versamenti oltre il limite e viene restituito l'errore PPT_SINTASSI_XSD

--- a/src/integration/wisp/features/nodoInviaCarrelloRPT/nodoInviaCarrelloRPT_withStamp.feature
+++ b/src/integration/wisp/features/nodoInviaCarrelloRPT/nodoInviaCarrelloRPT_withStamp.feature
@@ -97,3 +97,15 @@ Funzionalità: L'utente paga carrelli di pagamento con marche da bollo su nodoIn
     E una singola RPT di tipo BBT con 6 versamenti di cui 3 sono marche da bollo
     Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC senza verifica dell'URL di redirect
     Allora il pagamento fallisce having a quantity of transfers above the limit e viene restituito l'errore PPT_SINTASSI_XSD
+
+  # ===============================================================================================
+  # ===============================================================================================
+
+  @runnable @nodo_invia_carrello_rpt @unhappy_path
+  @FEAT_005_NodoInviaCarrelloRPT_WithStamp_SCENARIO_09
+  Scenario: L'utente tenta di pagare un carrello con due RPT che hanno una quantita di versamenti e marche da bollo oltre il limite
+    Dato un carrello di RPT non-multi-beneficiario
+    E una singola RPT di tipo BBT con 2 versamenti di cui 1 sono marche da bollo
+    E una singola RPT di tipo BBT con 6 versamenti di cui 2 sono marche da bollo
+    Quando l'utente tenta di pagare il carrello di RPT sul sito dell'EC senza verifica dell'URL di redirect
+    Allora il pagamento fallisce having a quantity of transfers above the limit e viene restituito l'errore PPT_SINTASSI_XSD


### PR DESCRIPTION
#### List of Changes
- Reintegrated missing scenarios from branch PQ-523-ai-tool-implementation into Italian feature files under src/integration/wisp/features/nodoInviaCarrelloRPT/.
- Translated missing scenarios from English to Italian; inserted only missing scenarios and preserved existing file content; renumbered scenario tags sequentially.

#### Motivation and Context
- Ensure parity with the older branch and restore test coverage for the 
odoInviaCarrelloRPT suite.

#### How Has This Been Tested?
- Ran ehave --dry-run across modified suites: 70 scenarios, 425 steps, 0 undefined.
- Verified no undefined steps and that existing step implementations in src/integration/wisp/steps/steps.py cover the added scenarios.

#### Screenshots (if appropriate):
- none

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Files changed
- src/integration/wisp/features/nodoInviaCarrelloRPT/nodoInviaCarrelloRPT_existingPaymentPosition.feature
- src/integration/wisp/features/nodoInviaCarrelloRPT/nodoInviaCarrelloRPT_noStamp.feature
- src/integration/wisp/features/nodoInviaCarrelloRPT/nodoInviaCarrelloRPT_withStamp.feature
