### PR TITLE
PQ-542 - Refactor secret handling: config loader & Azure resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,23 +220,16 @@ I secret utilizzati dall'applicazione possono essere:
 - risolti da un file di secret (per il testing in locale);
 - risolti dal key vault Azure relativo all'ambiente di test (dev, uat).
 
-Inoltre, è presente l'`ApimSubscriptionResolver`, utilizzato per risolvere le subscription key dei servizi, leggendole dal servizio APIM di Azure relativo all'ambiente di test (dev,uat).
-
-I resolver (che siano di secret o di subscription keys) possono essere usati in maniera sequenziale in quanto il sistema di risoluzione accetta, oltre al singolo resolver, una lista.
-
-La lista permette al sistema di provare la risoluzione di un secret più di una volta, siccome in caso di mancata risoluzione con un resolver, si passerà al successivo; la mancata risoluzione definitiva di un secret solleva un eccezione, interrompendo il flusso applicativo.
+Inoltre, è presente l'`ApimSubscriptionResolver`, utilizzato per risolvere le subscription key dei servizi, leggendole dal servizio APIM di Azure relativo all'ambiente di test (dev,uat), al momento però **non è impiegato**.
 
 
 #### Requisiti comuni
-Per entrambe le casistiche, è necessario che nel workspace siano presenti:
-- un file denominato "common_placeholders.json" contenente i secret comuni a più suite di test;
-- un file specifico per la singola suite, denominato "{suite}_placeholders.json" (es. wisp_placeholders.json).
+Per entrambe le casistiche, è necessario che nel workspace sia presente:
+- un file specifico per la singola suite, denominato "{suite}_config.json" (es. wisp_config.json), contenente sia i secrets della suite che le sue configurazioni (es. url di un servizio, timeout, ecc...)
 
+L'applicazione risolverà poi i secret presenti nel file e li assegnerà nell'attributo secret presente nell'oggetto context, per accedere al secret bisognerà richiamarlo utilizzando il nome ad esso associato nel file in cui è presente. es. `context.secret.NOME_SECRET` 
 
-
-L'applicazione risolverà poi i secret presenti in entrambi i file e li assegnerà nell'attributo secret presente nell'oggetto context, per accedere al secret bisognerà richiamarlo utilizzando il nome ad esso associato nel file in cui è presente. es. `context.secret.NOME_SECRET` 
-
-In locale è necessario che entrambi i file siano inseriti manualmente nel workspace, rispettivamente sotto la cartelle `./config/` e `./config/suites/`; invece durante l'esecuzione della suite di test tramite github i file saranno iniettati in quelle locations dal runner github. 
+È necessario che il file sia inserito manualmente nel workspace, sotto la cartelle `./config/suites_config/`.
 
 
 Il formato dei secret da risolvere all'interno dei file JSON **DEVE** essere il seguente:
@@ -258,10 +251,12 @@ Esempio:
 ```
 {
   "uat":{
-    "EXAMPLE_SECRET": "$EXAMPLE_SECRET"
+    "EXAMPLE_SECRET": "$EXAMPLE_SECRET",
+    "EXAMPLE_CONFIG": "CONFIG"
   },
   "dev":{
-    "EXAMPLE_SECRET": "$EXAMPLE_SECRET"
+    "EXAMPLE_SECRET": "$EXAMPLE_SECRET",
+    "EXAMPLE_CONFIG": "CONFIG"
   }
 }
 ```
@@ -271,7 +266,7 @@ L'applicazione ha bisogno che siano settate le seguenti variabili d'ambiente:
 - `TARGET_ENV` -> Utilizzata per indicare l'env da cui leggere i placeholders, sia per i secret   comuni che per quelli specifici per la suite;
 
 #### Risoluzione secret in locale
-Per la risoluzione locale dei secret è necessario che sia presente un file `secrets.yaml` sotto `./config/`, affinchè il sistema possa utilizzarlo per risolvere i secret presenti in entrambi i file di placeholders.
+Per la risoluzione locale dei secret è necessario che sia presente un file `secrets.yaml` sotto `./config/`, affinchè il sistema possa utilizzarlo per risolvere i secret presenti nel file di config.
 
 #### Autenticazione Azure
 L'autenticazione verso Azure avviene tramite `DefaultAzureCredential`, che prova in sequenza le credenziali disponibili nell'ambiente di esecuzione fino a trovare un'identità valida. Questo meccanismo viene usato sia per la risoluzione dei secret dal Key Vault Azure sia per il recupero delle subscription key da APIM, così da avere un unico modello di autenticazione per entrambi i resolver.
@@ -299,9 +294,6 @@ Per la risoluzione dei secret dal Key vault è necessario che sia presente la va
 
 #### Risoluzione secret da APIM
 Per la risoluzione delle subscription key da APIM è necessario che siano presenti le variabili d'ambiente `AZURE_SUBSCRIPTION_ID`, `APIM_RESOURCE_GROUP` e `APIM_SERVICE_NAME`, così che il resolver possa creare il client di management e recuperare la subscription key corretta dal servizio APIM. Il nome del secret può essere un nome logico mappato tramite la variabile `APIM_SUBSCRIPTION_<NAME>` oppure direttamente l'identificativo della subscription APIM; inoltre, è possibile richiedere la chiave `primary` o `secondary` usando il suffisso `:primary` o `:secondary`.
-
-
-
 
 ## Suite disponibili
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,96 @@ export E2E_TIMEOUT_MS=80000
 
 Riferimenti: `src/e2e/checkout/environment.py`, `src/e2e/checkout/dev.env`.
 
+### Gestione dei secret
+
+L'applicazione fa uso di svariati secret per eseguire correttamente le suite di test.
+I secret utilizzati dall'applicazione possono essere:
+- risolti da un file di secret (per il testing in locale);
+- risolti dal key vault Azure relativo all'ambiente di test (dev, uat).
+
+Inoltre, è presente l'`ApimSubscriptionResolver`, utilizzato per risolvere le subscription key dei servizi, leggendole dal servizio APIM di Azure relativo all'ambiente di test (dev,uat).
+
+I resolver (che siano di secret o di subscription keys) possono essere usati in maniera sequenziale in quanto il sistema di risoluzione accetta, oltre al singolo resolver, una lista.
+
+La lista permette al sistema di provare la risoluzione di un secret più di una volta, siccome in caso di mancata risoluzione con un resolver, si passerà al successivo; la mancata risoluzione definitiva di un secret solleva un eccezione, interrompendo il flusso applicativo.
+
+
+#### Requisiti comuni
+Per entrambe le casistiche, è necessario che nel workspace siano presenti:
+- un file denominato "common_placeholders.json" contenente i secret comuni a più suite di test;
+- un file specifico per la singola suite, denominato "{suite}_placeholders.json" (es. wisp_placeholders.json).
+
+
+
+L'applicazione risolverà poi i secret presenti in entrambi i file e li assegnerà nell'attributo secret presente nell'oggetto context, per accedere al secret bisognerà richiamarlo utilizzando il nome ad esso associato nel file in cui è presente. es. `context.secret.NOME_SECRET` 
+
+In locale è necessario che entrambi i file siano inseriti manualmente nel workspace, rispettivamente sotto la cartelle `./config/` e `./config/suites/`; invece durante l'esecuzione della suite di test tramite github i file saranno iniettati in quelle locations dal runner github. 
+
+
+Il formato dei secret da risolvere all'interno dei file JSON **DEVE** essere il seguente:
+` "NOME_NON_VINCOLANTE" : "$NOME_SECRET_VINCOLANTE" `.
+
+Il nome dell'attributo JSON non è vincolante in quanto rappresenta solo il nome che utilizzeremo all'interno del codice per accedere al secret, il valore dell'attributo invece è vincolante in quanto sarà utilizzato per individuare il secret da cui leggere il valore, che sarà poi settato come valore per quell'attributo.
+
+
+```
+FLUSSO D'ESEMPIO:
+- Ho un attributo "API_KEY_TEST" : "$API_KEY_WISP"
+- Il resolver cerca un secret denominato API_KEY_WISP
+- Lo trova e lo sostituisce a "$API_KEY_WISP" nel file JSON 
+- "API_KEY_TEST" : "XXXXXXXXX"
+- Accedo all'attributo nel codice con "context.secret.API_KEY_TEST"
+```
+Tutti i placeholder all'interno dei JSON **devono** essere suddivisi per ambiente, inserendoli dentro un oggetto avente come nome la denominazione dell'ambiente di riferimento, così che l'applicazione possa risolvere i secret corretti per l'ambiente d'esecuzione.
+Esempio:
+```
+{
+  "uat":{
+    "EXAMPLE_SECRET": "$EXAMPLE_SECRET"
+  },
+  "dev":{
+    "EXAMPLE_SECRET": "$EXAMPLE_SECRET"
+  }
+}
+```
+
+L'applicazione ha bisogno che siano settate le seguenti variabili d'ambiente:
+-  `suite` -> Utilizzata per individuare il file di placeholders specifico per la suite;
+- `TARGET_ENV` -> Utilizzata per indicare l'env da cui leggere i placeholders, sia per i secret   comuni che per quelli specifici per la suite;
+
+#### Risoluzione secret in locale
+Per la risoluzione locale dei secret è necessario che sia presente un file `secrets.yaml` sotto `./config/`, affinchè il sistema possa utilizzarlo per risolvere i secret presenti in entrambi i file di placeholders.
+
+#### Autenticazione Azure
+L'autenticazione verso Azure avviene tramite `DefaultAzureCredential`, che prova in sequenza le credenziali disponibili nell'ambiente di esecuzione fino a trovare un'identità valida. Questo meccanismo viene usato sia per la risoluzione dei secret dal Key Vault Azure sia per il recupero delle subscription key da APIM, così da avere un unico modello di autenticazione per entrambi i resolver.
+I principali metodi di autenticazione provati da Azure sono, in ordine:
+
+- EnvironmentCredential -> Richiede le seguenti variabili d'ambiente:
+
+  1.AZURE_TENANT_ID: L'ID Microsoft Entra tenant (directory).
+
+  2.AZURE_CLIENT_ID: ID client (applicazione) di una registrazione dell'app nel tenant.
+
+  3.AZURE_CLIENT_SECRET o AZURE_CLIENT_CERTIFICATE_PATH: Il primo è il segreto client generato per la registrazione dell'app, il secondo invece è il percorso di un certificato PEM da usare durante l'autenticazione, da usare come alternativa al client secret.
+
+
+- WorkloadIdentityCredential -> Consente alle applicazioni in esecuzione su macchine virtuali (VM) di accedere ad altre risorse Azure senza la necessità di un principale di servizio o di un'identità gestita.
+
+- ManagedIdentityCredential -> Tenta di eseguire l'autenticazione usando un'identità gestita disponibile nell'ambiente di distribuzione. Questo tipo di autenticazione funziona in VM Azure, istanze App Service, applicazioni Funzioni di Azure, Azure Kubernetes Services, istanze Azure Service Fabric e all'interno di Azure Cloud Shell.
+
+- AzureCliCredential -> Tenta di eseguire l'autenticazione tramite lo strumento a linea di comando di Azure ("az"). Per farlo, leggerà il token di accesso utente e il tempo di scadenza con il comando interfaccia della riga di comando di Azure "az account get-access-token". Da usare in seguito ad un "az login".
+
+
+#### Risoluzione secret dal Key Vault Azure
+Per la risoluzione dei secret dal Key vault è necessario che sia presente la variabile d'ambiente `AZURE_KEY_VAULT_URL`, contenente l'url del Key Vault Azure; la sua presenza è necessaria anche per indicare al sistema di utilizzare il Key Vault e non il resolver locale.
+ **Attenzione**: È presente un Key Vault per DEV ed uno per UAT, quindi è necessario fornire un URL differente in base all'ambiente;
+
+#### Risoluzione secret da APIM
+Per la risoluzione delle subscription key da APIM è necessario che siano presenti le variabili d'ambiente `AZURE_SUBSCRIPTION_ID`, `APIM_RESOURCE_GROUP` e `APIM_SERVICE_NAME`, così che il resolver possa creare il client di management e recuperare la subscription key corretta dal servizio APIM. Il nome del secret può essere un nome logico mappato tramite la variabile `APIM_SUBSCRIPTION_<NAME>` oppure direttamente l'identificativo della subscription APIM; inoltre, è possibile richiedere la chiave `primary` o `secondary` usando il suffisso `:primary` o `:secondary`.
+
+
+
+
 ## Suite disponibili
 
 ### API

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Per entrambe le casistiche, è necessario che nel workspace sia presente:
 
 L'applicazione risolverà poi i secret presenti nel file e li assegnerà nell'attributo secret presente nell'oggetto context, per accedere al secret bisognerà richiamarlo utilizzando il nome ad esso associato nel file in cui è presente. es. `context.secret.NOME_SECRET` 
 
-È necessario che il file sia inserito manualmente nel workspace, sotto la cartelle `./config/suites_config/`.
+È necessario che il file sia inserito manualmente nel workspace, sotto la cartelle `./config/suites/`.
 
 
 Il formato dei secret da risolvere all'interno dei file JSON **DEVE** essere il seguente:

--- a/src/conf/configuration.py
+++ b/src/conf/configuration.py
@@ -2,6 +2,10 @@
 """
 import logging
 import os
+from src.utility.config.config_loader import load_json_config
+from src.utility.config.secrets.azure_secret_resolver import AzureKeyVaultSecretResolver
+from src.utility.config.secrets.apim_subscription_resolver import ApimSubscriptionResolver
+from src.utility.config.secrets.secret_resolver import DictSecretResolver
 
 import urllib3
 from dynaconf import Dynaconf
@@ -9,6 +13,12 @@ from dynaconf import Dynaconf
 ENV_VAR_PREFIX = 'WISP_DISMANTLING'
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+def check_apim_variables():
+    """Check if the required APIM environment variables are set."""
+    required_vars = ["AZURE_SUBSCRIPTION_ID", "APIM_RESOURCE_GROUP", "APIM_SERVICE_NAME"]
+    missing_vars = [var for var in required_vars if not os.environ.get(var)]
+    return True if missing_vars == [] else False
 
 # `envvar_prefix` = export envvars with ENV_VAR_PREFIX as prefix.
 # `settings_files` = Load settings files in the order.
@@ -24,14 +34,25 @@ settings = settings[os.environ['TARGET_ENV']]
 
 # Load the secrets for the specified environment
 secrets = {}
+secrets_resolver = list()
 
-try:
-    all_secrets = Dynaconf(settings_files=settings.SECRET_PATH)
-    if settings.TARGET_ENV in all_secrets:
-        secrets = all_secrets[settings.TARGET_ENV]
-except AttributeError as e:
-    logging.error(e)
-    exit()
+# select the type of secret resolver based on the environment (CI or local testing)
+if os.getenv("AZURE_KEY_VAULT_URL") is not None and os.getenv("AZURE_KEY_VAULT_URL") != "":
+    # resolve secrets from Azure Key Vault in CI, otherwise use DictSecretResolver for local testing
+    secrets_resolver.append(AzureKeyVaultSecretResolver())
+    if check_apim_variables():
+        secrets_resolver.append(ApimSubscriptionResolver())
+else:
+    # resolve secrets from DictSecretResolver for local testing, takes a dictonary of secrets which he uses to resolve secrets founds in the test config file
+    try:
+        all_secrets = Dynaconf(settings_files=settings.SECRET_PATH)
+        if settings.TARGET_ENV in all_secrets:
+            secrets_resolver = DictSecretResolver( all_secrets[settings.TARGET_ENV])
+    except Exception as e:
+        logging.error(e)
+        exit()
+
+secrets = load_json_config(secrets_resolver)
 
 commondata = Dynaconf(
     settings_files=['commondata.yaml'],

--- a/src/conf/configuration.py
+++ b/src/conf/configuration.py
@@ -34,14 +34,13 @@ settings = settings[os.environ['TARGET_ENV']]
 
 # Load the secrets for the specified environment
 secrets = {}
-secrets_resolver = list()
+secrets_resolver = None
 
 # select the type of secret resolver based on the environment (CI or local testing)
 if os.getenv("AZURE_KEY_VAULT_URL") is not None and os.getenv("AZURE_KEY_VAULT_URL") != "":
     # resolve secrets from Azure Key Vault in CI, otherwise use DictSecretResolver for local testing
-    secrets_resolver.append(AzureKeyVaultSecretResolver())
-    if check_apim_variables():
-        secrets_resolver.append(ApimSubscriptionResolver())
+    secrets_resolver = AzureKeyVaultSecretResolver()
+  
 else:
     # resolve secrets from DictSecretResolver for local testing, takes a dictonary of secrets which he uses to resolve secrets founds in the test config file
     try:
@@ -53,6 +52,8 @@ else:
         exit()
 
 secrets = load_json_config(secrets_resolver)
+if isinstance(secrets_resolver, AzureKeyVaultSecretResolver):
+    secrets_resolver.close_client()
 
 commondata = Dynaconf(
     settings_files=['commondata.yaml'],

--- a/src/utility/config/__init__.py
+++ b/src/utility/config/__init__.py
@@ -1,11 +1,10 @@
 """Config utility package.
 
 Espone:
-- load_test_config: carica il file JSON selezionato via env var
 - load_json_config: carica un file JSON dal percorso specificato
 """
 
-from src.utility.config.config_loader import load_json_config, load_test_config
+from src.utility.config.config_loader import load_json_config
 
-__all__ = ["load_json_config", "load_test_config"]
+__all__ = ["load_json_config"]
 

--- a/src/utility/config/config_loader.py
+++ b/src/utility/config/config_loader.py
@@ -20,7 +20,7 @@ from typing import Any, Dict
 # ============================================================================
 TARGET_ENV_VAR = "TARGET_ENV"
 SUITE_ENV_VAR = "suite"
-SUITE_FILE_PATH_PREFIX = "config/{suite}_config.json"
+SUITE_FILE_PATH_PREFIX = "config/suites/{suite}_config.json"
 
 # ============================================================================
 # Placeholder format

--- a/src/utility/config/config_loader.py
+++ b/src/utility/config/config_loader.py
@@ -18,11 +18,9 @@ from typing import Any, Dict
 #   TEST_CONFIG_FILE=config/tests/my_service.json behave src/...
 #
 # ============================================================================
-TEST_CONFIG_FILE_ENV_VAR = "TEST_CONFIG_FILE"
 TARGET_ENV_VAR = "TARGET_ENV"
 SUITE_ENV_VAR = "suite"
-COMMON_FILE_PATH = "config/common_placeholders.json"
-SUITE_FILE_PATH_PREFIX = "config/{suite}_placeholders.json"
+SUITE_FILE_PATH_PREFIX = "config/{suite}_config.json"
 
 # ============================================================================
 # Placeholder format
@@ -160,16 +158,13 @@ def load_json_config(secret_resolver: Any | list[Any]) -> Dict[str, Any]:
     if(os.getenv(TARGET_ENV_VAR) is None or os.getenv(TARGET_ENV_VAR) == "") or (os.getenv(SUITE_ENV_VAR) is None or os.getenv(SUITE_ENV_VAR) == ""):
         raise JsonConfigLoaderError(f"Environment variable '{TARGET_ENV_VAR}' or '{SUITE_ENV_VAR}' is not set. Set them to the target environment (e.g., 'uat', 'dev') and suite (e.g., 'wisp', 'cup').")
 
-    common_file_path = Path(COMMON_FILE_PATH)
     suite_file_path = Path(SUITE_FILE_PATH_PREFIX.replace("{suite}", os.getenv(SUITE_ENV_VAR)))
-    if not common_file_path.exists() or not suite_file_path.exists():
-        raise JsonConfigLoaderError(f"Config file not found: {common_file_path} or {suite_file_path}")
+    if not suite_file_path.exists():
+        raise JsonConfigLoaderError(f"Config file not found: {suite_file_path}")
 
-    common_content = common_file_path.read_text(encoding="utf-8")
     suite_content = suite_file_path.read_text(encoding="utf-8")
    
-    parsed_content = _parse_config_content(common_content, common_file_path).get(os.getenv(TARGET_ENV_VAR), {})
-    parsed_content.update(_parse_config_content(suite_content, suite_file_path).get(os.getenv(TARGET_ENV_VAR), {}))
+    parsed_content = _parse_config_content(suite_content, suite_file_path).get(os.getenv(TARGET_ENV_VAR), {})
 
     if not parsed_content:
         raise JsonConfigLoaderError(

--- a/src/utility/config/config_loader.py
+++ b/src/utility/config/config_loader.py
@@ -19,7 +19,10 @@ from typing import Any, Dict
 #
 # ============================================================================
 TEST_CONFIG_FILE_ENV_VAR = "TEST_CONFIG_FILE"
-
+TARGET_ENV_VAR = "TARGET_ENV"
+SUITE_ENV_VAR = "suite"
+COMMON_FILE_PATH = "config/common_placeholders.json"
+SUITE_FILE_PATH_PREFIX = "config/{suite}_placeholders.json"
 
 # ============================================================================
 # Placeholder format
@@ -31,12 +34,43 @@ TEST_CONFIG_FILE_ENV_VAR = "TEST_CONFIG_FILE"
 # corrispondente recuperato tramite il resolver passato al loader.
 
 
-SECRET_PLACEHOLDER_PATTERN = re.compile(r"^\$(?P<name>[A-Za-z0-9_]+)$")
+SECRET_PLACEHOLDER_PATTERN = re.compile(r"^\$(?P<name>[A-Za-z0-9_-]+)$")
 
 
 class JsonConfigLoaderError(Exception):
     """Eccezione del loader di configurazione JSON."""
     pass
+
+
+class AttributeDict(dict):
+    """Dictionary with recursive attribute-style access support."""
+
+    def __getattr__(self, item: str) -> Any:
+        """Return dictionary items using attribute access."""
+        try:
+            return self[item]
+        except KeyError as exc:
+            raise AttributeError(item) from exc
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        """Allow assigning dictionary items via attributes."""
+        self[key] = value
+
+    def __delattr__(self, item: str) -> None:
+        """Allow deleting dictionary items via attributes."""
+        try:
+            del self[item]
+        except KeyError as exc:
+            raise AttributeError(item) from exc
+
+
+def _to_attribute_dict(value: Any) -> Any:
+    """Recursively convert dict and list nodes to AttributeDict."""
+    if isinstance(value, dict):
+        return AttributeDict({k: _to_attribute_dict(v) for k, v in value.items()})
+    if isinstance(value, list):
+        return [_to_attribute_dict(item) for item in value]
+    return value
 
 
 def _resolve_value(value: Any, secret_resolver: Any) -> Any:
@@ -45,6 +79,7 @@ def _resolve_value(value: Any, secret_resolver: Any) -> Any:
         match = SECRET_PLACEHOLDER_PATTERN.match(value)
         if match:
             secret_name = match.group("name")
+
             # Support both a single resolver and a list/tuple of resolvers.
             resolvers = (
                 list(secret_resolver)
@@ -89,76 +124,7 @@ def _resolve_value(value: Any, secret_resolver: Any) -> Any:
     # Numeri, booleani, null ecc. restano invariati.
     return value
 
-
-def _parse_key_value_config(raw_content: str) -> Dict[str, Any]:
-    """Parse formato key:value o key=value, con supporto valori JSON/stringa."""
-    parsed: Dict[str, Any] = {}
-
-    lines = raw_content.splitlines()
-    i = 0
-    while i < len(lines):
-        raw_line = lines[i]
-        line_number = i + 1
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
-            i += 1
-            continue
-
-        idx_colon = raw_line.find(":")
-        idx_equal = raw_line.find("=")
-        if idx_colon == -1 and idx_equal == -1:
-            raise JsonConfigLoaderError(
-                f"Invalid config line at {line_number}: '{raw_line}'. Expected 'key:value' or 'key=value'."
-            )
-
-        if idx_equal != -1 and (idx_colon == -1 or idx_equal < idx_colon):
-            key, raw_value = raw_line.split("=", 1)
-        else:
-            key, raw_value = raw_line.split(":", 1)
-
-        key = key.strip()
-        value_text = raw_value.strip()
-
-        if not key:
-            raise JsonConfigLoaderError(
-                f"Invalid empty key at line {line_number}: '{raw_line}'."
-            )
-
-        if value_text.startswith(("'", '"')):
-            quote = value_text[0]
-            if len(value_text) >= 2 and value_text.endswith(quote):
-                value_text = value_text[1:-1]
-            else:
-                buffer = [value_text[1:]]
-                i += 1
-                closed = False
-                while i < len(lines):
-                    current = lines[i]
-                    if current.endswith(quote):
-                        buffer.append(current[:-1])
-                        closed = True
-                        break
-                    buffer.append(current)
-                    i += 1
-
-                if not closed:
-                    raise JsonConfigLoaderError(
-                        f"Unclosed multiline quoted value for key '{key}' at line {line_number}."
-                    )
-                value_text = "\n".join(buffer)
-
-        # Se il valore e' JSON valido lo converte, altrimenti resta stringa raw.
-        try:
-            value = json.loads(value_text)
-        except json.JSONDecodeError:
-            value = value_text
-
-        parsed[key] = value
-        i += 1
-
-    return parsed
-
-
+    
 def _parse_config_content(raw_content: str, file_path: Path) -> Dict[str, Any]:
     """Parse JSON object completo, altrimenti fallback a key:value."""
     try:
@@ -169,10 +135,12 @@ def _parse_config_content(raw_content: str, file_path: Path) -> Dict[str, Any]:
             )
         return parsed
     except json.JSONDecodeError:
-        return _parse_key_value_config(raw_content)
+        raise JsonConfigLoaderError(
+            f"Invalid JSON format in file {file_path}."
+        )
 
 
-def load_json_config(path: str | Path, secret_resolver: Any | list[Any]) -> Dict[str, Any]:
+def load_json_config(secret_resolver: Any | list[Any]) -> Dict[str, Any]:
     """
     Legge un file di configurazione e risolve i placeholder "$var_name".
 
@@ -188,68 +156,26 @@ def load_json_config(path: str | Path, secret_resolver: Any | list[Any]) -> Dict
         default_headers:{"Content-Type":"application/json"}
         oauth2:{"client_id":"my-client","client_secret":"$oauth_client_secret"}
     """
-    # Notes:
-    #     `secret_resolver` può essere un singolo resolver oppure una lista/tupla
-    #     di resolver; in quest'ultimo caso vengono interrogati in ordine e la
-    #     prima risoluzione non-`None` viene utilizzata.
-    file_path = Path(path)
+   
+    if(os.getenv(TARGET_ENV_VAR) is None or os.getenv(TARGET_ENV_VAR) == "") or (os.getenv(SUITE_ENV_VAR) is None or os.getenv(SUITE_ENV_VAR) == ""):
+        raise JsonConfigLoaderError(f"Environment variable '{TARGET_ENV_VAR}' or '{SUITE_ENV_VAR}' is not set. Set them to the target environment (e.g., 'uat', 'dev') and suite (e.g., 'wisp', 'cup').")
 
-    if not file_path.exists():
-        raise JsonConfigLoaderError(f"Config file not found: {file_path}")
+    common_file_path = Path(COMMON_FILE_PATH)
+    suite_file_path = Path(SUITE_FILE_PATH_PREFIX.replace("{suite}", os.getenv(SUITE_ENV_VAR)))
+    if not common_file_path.exists() or not suite_file_path.exists():
+        raise JsonConfigLoaderError(f"Config file not found: {common_file_path} or {suite_file_path}")
 
-    raw_content = file_path.read_text(encoding="utf-8")
-    raw = _parse_config_content(raw_content, file_path)
+    common_content = common_file_path.read_text(encoding="utf-8")
+    suite_content = suite_file_path.read_text(encoding="utf-8")
+   
+    parsed_content = _parse_config_content(common_content, common_file_path).get(os.getenv(TARGET_ENV_VAR), {})
+    parsed_content.update(_parse_config_content(suite_content, suite_file_path).get(os.getenv(TARGET_ENV_VAR), {}))
 
-    return _resolve_value(raw, secret_resolver)
-
-
-def load_test_config(secret_resolver: Any | list[Any]) -> Dict[str, Any]:
-    """
-    Carica il file JSON di configurazione il cui percorso è definito
-    nella variabile d'ambiente TEST_CONFIG_FILE.
-
-    Permette di selezionare il file di test al momento del lancio senza
-    modificare il codice, rendendo la stessa suite eseguibile con
-    configurazioni diverse (es. ambienti dev/uat/prod).
-
-    Args:
-        secret_resolver: oggetto (o lista di oggetti) con metodo
-            `resolve(secret_name: str) -> Any`. Se viene passata una lista, i
-            resolver vengono interrogati in ordine.
-
-    Returns:
-        Dizionario Python con segreti già sostituiti.
-
-    Raises:
-        JsonConfigLoaderError: se TEST_CONFIG_FILE non è impostata o il file non esiste.
-
-    Esempio di lancio (PowerShell)::
-
-        $env:TEST_CONFIG_FILE = "config/tests/service_dev.json"
-        behave src/api/my-service
-
-    Esempio di lancio (bash)::
-
-        TEST_CONFIG_FILE=config/tests/service_uat.json behave src/api/my-service
-
-    Esempio in environment.py di Behave::
-
-        from src.utility.config.config_loader import load_test_config
-        from src.utility.config.secrets import DictSecretResolver, AzureKeyVaultSecretResolver
-
-        def before_all(context):
-            # In locale usa DictSecretResolver, in CI usa AzureKeyVaultSecretResolver
-            if os.environ.get("CI"):
-                resolver = AzureKeyVaultSecretResolver()
-            else:
-                resolver = DictSecretResolver({"client_secret": "local-secret"})
-
-            context.test_config = load_test_config(resolver)
-    """
-    config_file = os.environ.get(TEST_CONFIG_FILE_ENV_VAR)
-    if not config_file:
+    if not parsed_content:
         raise JsonConfigLoaderError(
-            f"Environment variable '{TEST_CONFIG_FILE_ENV_VAR}' is not set. "
-            f"Set it to the path of the JSON config file to use for the tests."
+            f"Impossible to find or parse configuration for environment '{os.getenv(TARGET_ENV_VAR)}' and suite '{os.getenv(SUITE_ENV_VAR)}' in file {file_path}."
         )
-    return load_json_config(config_file, secret_resolver)
+
+    resolved = _resolve_value(parsed_content, secret_resolver)
+    return _to_attribute_dict(resolved)
+    

--- a/src/utility/config/secrets/azure_secret_resolver.py
+++ b/src/utility/config/secrets/azure_secret_resolver.py
@@ -45,8 +45,14 @@ class AzureKeyVaultSecretResolver(SecretResolver):
             os.environ["AZURE_KEY_VAULT_URL"],
             credential or DefaultAzureCredential()
         )
+
         if not self._client:
             raise RuntimeError("AZURE_KEY_VAULT_URL must be set (or pass credential).")
+        
+    def close_client(self):
+        """Chiude il client di Azure Key Vault."""
+        if self._client:
+            self._client.close()
 
     def resolve(self, secret_name: str) -> Any:
         """
@@ -73,5 +79,4 @@ class AzureKeyVaultSecretResolver(SecretResolver):
 
         secret_name = secret_name.replace('_','-')
         secret = self._client.get_secret(secret_name)
-        self._client.close()
         return secret.value

--- a/src/utility/config/secrets/azure_secret_resolver.py
+++ b/src/utility/config/secrets/azure_secret_resolver.py
@@ -43,8 +43,10 @@ class AzureKeyVaultSecretResolver(SecretResolver):
     def __init__(self, credential = None):
         self._client = SecretClient(
             os.environ["AZURE_KEY_VAULT_URL"],
-            credential or DefaultAzureCredential()#to change credential manager
+            credential or DefaultAzureCredential()
         )
+        if not self._client:
+            raise RuntimeError("AZURE_KEY_VAULT_URL must be set (or pass credential).")
 
     def resolve(self, secret_name: str) -> Any:
         """
@@ -68,5 +70,8 @@ class AzureKeyVaultSecretResolver(SecretResolver):
             resolver = AzureKeyVaultSecretResolver()
             password = resolver.resolve("db-password")
         """
+
+        secret_name = secret_name.replace('_','-')
         secret = self._client.get_secret(secret_name)
+        self._client.close()
         return secret.value


### PR DESCRIPTION
#### List of Changes
- Refactored the Azure Key Vault secret resolver
- Added logic to use Key Vault resolver or local dict resolver
- Updated README

#### Motivation and Context

This change is required because until now we used a file containing the secrets, which made it less scalable and secure compared to the usage of the Key Vault.

#### How Has This Been Tested?

Tested locally with either the local dict resolver and the Azure Key Vault resolver, the application in both cases is able to solve the secrets and to use them inside the suites.

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [X ] My change requires a change to the documentation.
- [ X] I have updated the documentation accordingly.
