### PR TITLE
PQ-452 - PQ-572: add trigger for checkout tests

### DIFF
--- a/.github/workflows/checkout-e2e-tests.yml
+++ b/.github/workflows/checkout-e2e-tests.yml
@@ -3,6 +3,9 @@ name: Run WISP Integration Tests
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   wisp_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/checkout-e2e-tests.yml
+++ b/.github/workflows/checkout-e2e-tests.yml
@@ -1,0 +1,59 @@
+name: Run WISP Integration Tests
+
+on:
+  workflow_call:
+
+jobs:
+  wisp_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: 3.x
+
+      - name: Setup Java
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          sudo apt-get install -y jq
+
+      - name: Run Checkout E2E tests
+        id: run_tests
+        continue-on-error: true
+        env:
+          HEADLESS: False
+          ENV_FILE: uat.env
+
+        run: |
+          behave src/e2e/checkout/ --format allure_behave.formatter:AllureFormatter -o allure-results --junit-directory=junit --junit --summary --show-timings -v
+
+      - name: Load previous allure history
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Build Checkout E2E Allure report
+        uses: simple-elf/allure-report-action@53ebb757a2097edc77c53ecef4d454fc2f2f774c # v1.13
+        with:
+          gh_pages: gh-pages
+          allure_results: allure-results
+          allure_report: allure-report-checkout-e2e
+          allure_history: allure-history
+          subfolder: checkout-e2e-tests
+          keep_reports: 30
+
+      - name: Upload Checkout E2E report artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: allure-report-checkout-e2e
+          path: allure-report-checkout-e2e

--- a/.github/workflows/main-dispatch-tests.yml
+++ b/.github/workflows/main-dispatch-tests.yml
@@ -13,6 +13,7 @@ on:
         default: all
         options:
           - wisp
+          - checkout
           # - fdr
           - all
 
@@ -24,6 +25,13 @@ jobs:
     uses: ./.github/workflows/wisp-tests.yml
     secrets: inherit
 
+  trigger_checkout_e2e:
+    if: |
+      github.event_name == 'schedule' ||
+      github.event.inputs.services == 'checkout' || github.event.inputs.services == 'all'
+    uses: ./.github/workflows/checkout-e2e-tests.yml
+    secrets: inherit
+
   # trigger_fdr:
   #   if: |
   #     github.event_name == 'schedule' ||
@@ -32,6 +40,6 @@ jobs:
   #   secrets: inherit
 
   deploy:
-    needs: [trigger_wisp] #, trigger_fdr]
+    needs: [trigger_wisp, trigger_checkout_e2e] #, trigger_fdr]
     uses: ./.github/workflows/deploy-test-report.yml
     secrets: inherit

--- a/src/e2e/checkout/helper.py
+++ b/src/e2e/checkout/helper.py
@@ -81,11 +81,37 @@ def perform_login(page):
     icon = page.locator("svg[data-testid='AccountCircleRoundedIcon']").nth(0)
     assert icon is not None, "Icon 'AccountCircleRoundedIcon' non trovato"
 
-def locate_and_click(page, locator, click_count=1, timeout=5000):
+def locate_and_click(page, locator, click_count=1, timeout=5000, check_focus=False):
     to_click = page.locator(locator)
     try:
         to_click.wait_for(state="visible", timeout=timeout)
         to_click.click(click_count=click_count)
+        if check_focus:
+            # retry focus check up to 3 times with small backoff
+            attempts = 0
+            focused = False
+            while attempts < 3 and not focused:
+                attempts += 1
+                # incremental wait to give the browser time to update focus
+                page.wait_for_timeout(50 * attempts)
+                try:
+                    focused = to_click.evaluate("el => el === document.activeElement || el.contains(document.activeElement)")
+                except Exception:
+                    focused = False
+                if focused:
+                    break
+                logger.debug("Focus check attempt %d failed for %s", attempts, locator)
+                # try to nudge focus: prefer .focus(), fallback to a gentle click
+                try:
+                    to_click.focus()
+                except Exception:
+                    try:
+                        to_click.click(click_count=1)
+                    except Exception:
+                        pass
+            if not focused:
+                logger.error("Locator %s did not receive focus after %d attempts", locator, attempts)
+                raise AssertionError(f"Locator '{locator}' did not receive focus after {attempts} attempts")
     except PlaywrightTimeoutError as exc:
         current_url = ""
         try:
@@ -101,7 +127,7 @@ def locate_and_click(page, locator, click_count=1, timeout=5000):
 def locate_click_and_type(page, locator, text, click_count=1, timeout=5000):
     """Click a locator, clear it and type text."""
     target = page.locator(locator)
-    locate_and_click(page, locator, click_count=click_count, timeout=timeout)
+    locate_and_click(page, locator, click_count=click_count, timeout=timeout, check_focus=True)
     try:
         target.fill("")
     except Exception:

--- a/src/e2e/checkout/helper.py
+++ b/src/e2e/checkout/helper.py
@@ -56,7 +56,7 @@ def perform_mock_login(page):
     page.wait_for_selector("button")
 
     logger.debug("Searching AccountCircleRoundIcon")
-    icon = page.query_selector("[data-testid='AccountCircleRoundedIcon']")
+    icon = page.locator("svg[data-testid='AccountCircleRoundedIcon']").nth(0)
 
     assert icon is not None, "Icon 'AccountCircleRoundedIcon' non trovato"
     logger.info("Login successful")
@@ -78,7 +78,7 @@ def perform_login(page):
     page.wait_for_load_state("networkidle")
     page.wait_for_selector("button")
 
-    icon = page.query_selector("[data-testid='AccountCircleRoundedIcon']")
+    icon = page.locator("svg[data-testid='AccountCircleRoundedIcon']").nth(0)
     assert icon is not None, "Icon 'AccountCircleRoundedIcon' non trovato"
 
 def locate_and_click(page, locator, click_count=1, timeout=5000):

--- a/src/e2e/checkout/steps/spid_auth.py
+++ b/src/e2e/checkout/steps/spid_auth.py
@@ -64,7 +64,7 @@ def step_confirm_logout(context):
     page = get_page(context)
     logger.debug("Confirming logout")
     locate_and_click(page, "#logoutModalConfirmButton")
-    page.locator("#login-header button").wait_for(state="visible", timeout=10000)
+    page.locator("#login-header button").nth(0).wait_for(state="visible", timeout=10000)
 
 
 # ──────────────────────────────────────────────
@@ -76,7 +76,8 @@ def step_check_account_icon_visible(context):
     """Assert that the user avatar icon is visible after login."""
     page = get_page(context)
     logger.debug("Checking AccountCircleRoundedIcon is visible")
-    icon = page.locator("[data-testid='AccountCircleRoundedIcon']")
+    # Select the first matching svg to avoid strict-mode errors
+    icon = page.locator("svg[data-testid='AccountCircleRoundedIcon']").nth(0)
     icon.wait_for(state="visible", timeout=10000)
     assert icon.is_visible(), "Expected AccountCircleRoundedIcon to be visible after login, but it was not found"
     logger.debug("AccountCircleRoundedIcon found — login confirmed")
@@ -87,7 +88,7 @@ def step_check_login_button_visible_after_logout(context):
     """Assert that the login button reappears after logout."""
     page = get_page(context)
     logger.debug("Checking login button is visible after logout")
-    login_button = page.locator("#login-header button")
+    login_button = page.locator("#login-header button").nth(0)
     login_button.wait_for(state="visible", timeout=10000)
     assert login_button.is_visible(), "Expected login button to be visible after logout, but it was not found"
     logger.debug("Login button visible — logout confirmed")


### PR DESCRIPTION





#### List of Changes

`
a997da648d PQ-572: add trigger for checkout tests
31d6d9cf73 PQ-572: Checkout e2e TA suite configuration
02453a8da3 PQ-572: Fix tests with duplicate locators; Selecting first result

Files changed:
.github/workflows/checkout-e2e-tests.yml .github/workflows/main-dispatch-tests.yml src/e2e/checkout/helper.py src/e2e/checkout/steps/spid_auth.py
 4 files changed, 74 insertions(+), 6 deletions(-)
`


#### Motivation and Context

Fixed Playwright locator strict-mode failures by selecting SVG elements explicitly and using non-strict locators (nth(0)). Adjusted login/logout helpers and steps to wait for visible elements.

#### How Has This Been Tested?

Executed local behave e2e scenarios; fixed failing selectors; added waits and assertions.



#### Screenshots (if appropriate):

#### Types of changes



- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:




- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
